### PR TITLE
Add ESP8266 Compatibility

### DIFF
--- a/utility/direct_pin_read.h
+++ b/utility/direct_pin_read.h
@@ -8,7 +8,7 @@
 #define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
 #define DIRECT_PIN_READ(base, mask)     (((*(base)) & (mask)) ? 1 : 0)
 
-#elif defined(__SAM3X8E__)
+#elif defined(__SAM3X8E__)  // || defined(ESP8266)
 
 #define IO_REG_TYPE			uint32_t
 #define PIN_TO_BASEREG(pin)             (portInputRegister(digitalPinToPort(pin)))
@@ -21,6 +21,19 @@
 #define PIN_TO_BASEREG(pin)             (portModeRegister(digitalPinToPort(pin)))
 #define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
 #define DIRECT_PIN_READ(base, mask)	(((*(base+4)) & (mask)) ? 1 : 0)
+
+/* ESP8266 v2.0.0 Arduino workaround for bug https://github.com/esp8266/Arduino/issues/1110
+   Once ESP8266 Arduino v2.1.0 is released, this #elif should be removed and line 11 of this
+   file should read:
+   #elif defined(__SAM3X8E__) || defined(ESP8266)
+*/
+#elif defined(ESP8266)
+
+#define IO_REG_TYPE			uint32_t
+#define PIN_TO_BASEREG(pin)             ((volatile uint32_t *)(0x60000000+(0x318))) //Bypassing erroneous preprocessor macros
+#define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
+#define DIRECT_PIN_READ(base, mask)     (((*(base)) & (mask)) ? 1 : 0)
+/* End of workaround */
 
 #endif
 

--- a/utility/interrupt_pins.h
+++ b/utility/interrupt_pins.h
@@ -143,6 +143,21 @@
   #define CORE_INT52_PIN	52
   #define CORE_INT53_PIN	53
 
+// ESP8266 (https://github.com/esp8266/Arduino/)
+#elif defined(ESP8266)
+  #define CORE_NUM_INTERRUPT EXTERNAL_NUM_INTERRUPTS
+  #define CORE_INT0_PIN		0
+  #define CORE_INT1_PIN		1
+  #define CORE_INT2_PIN		2
+  #define CORE_INT3_PIN		3
+  #define CORE_INT4_PIN		4
+  #define CORE_INT5_PIN		5
+  // GPIO6-GPIO11 are typically used to interface with the flash memory IC on 
+  // most esp8266 modules, so we should avoid adding interrupts to these pins.
+  #define CORE_INT12_PIN	12
+  #define CORE_INT13_PIN	13
+  #define CORE_INT14_PIN	14
+  #define CORE_INT15_PIN	15
 #endif
 #endif
 

--- a/utility/interrupt_pins.h
+++ b/utility/interrupt_pins.h
@@ -158,6 +158,7 @@
   #define CORE_INT13_PIN	13
   #define CORE_INT14_PIN	14
   #define CORE_INT15_PIN	15
+
 #endif
 #endif
 


### PR DESCRIPTION
Added ESP8266 direct_pin_read.h definitions, and workaround for current v2.0.0 of ESP8266 Arduino.
Includes instruction on removing the workaround once v2.1.0 is released and this bug is fixed:
esp8266/Arduino#1110