### PR TITLE
Leonardo: add digital pin 7 as an interrupt

### DIFF
--- a/utility/interrupt_pins.h
+++ b/utility/interrupt_pins.h
@@ -49,11 +49,12 @@
 
 // Arduino Leonardo (untested)
 #elif defined(__AVR_ATmega32U4__) && !defined(CORE_TEENSY)
-  #define CORE_NUM_INTERRUPT	4
+  #define CORE_NUM_INTERRUPT	5
   #define CORE_INT0_PIN		3
   #define CORE_INT1_PIN		2
   #define CORE_INT2_PIN		0
   #define CORE_INT3_PIN		1
+  #define CORE_INT4_PIN		7
 
 // Sanguino (untested)
 #elif defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644__)


### PR DESCRIPTION
(This is tested, but I am not certain about the twisty little maze of pin-to-pin-to-interrupt mappings.)

On Leonardo/32u4, digital pin 7 (aka PE6, aka INT6) is connected to Arduino core interrupt 4. For the Arduino mapping, see:

https://github.com/arduino/Arduino/blob/master/hardware/arduino/avr/cores/arduino/WInterrupts.c#L102

Tested with this variant on the Basic example:

```
  Encoder myEnc(7, 6);
  void loop() {
    // demonstrate encoder changes are registered while not being read()
    delay(1000);
    long newPosition = myEnc.read();
    if (newPosition != oldPosition) {
      oldPosition = newPosition;
      Serial.println(newPosition);
    }
  }
```

I have not removed the “untested” comment on the Leonardo definition, as I have not tested pins 0-3.