### PR TITLE
Fix Zero and MKR1000 interrupts

### DIFF
--- a/utility/interrupt_pins.h
+++ b/utility/interrupt_pins.h
@@ -160,8 +160,7 @@
   #define CORE_INT14_PIN	14
   #define CORE_INT15_PIN	15
 
-// Arduino Zero - TODO: interrupts do not seem to work
-//                      please help, contribute a fix!
+// Arduino Zero
 #elif defined(__SAMD21G18A__)
   #define CORE_NUM_INTERRUPT	20
   #define CORE_INT0_PIN		0


### PR DESCRIPTION
I've found that interrupts do not work on my M0 and MKR1000. After some investigation I found that we can't call attachInterrupt() before setup() on MKR1000. Here is my fix. I tested this patch on my MKR1000.

This fix includes addition of new public method 'begin()'. This method is supposed to be called in  the setup() by user though it will be called in read() implicitly.