### PR TITLE
fix esp8266 crash on interrupt routines

### DIFF
--- a/Encoder.h
+++ b/Encoder.h
@@ -38,6 +38,10 @@
 #include "pins_arduino.h"
 #endif
 
+#ifndef ICACHE_FLASH
+#define ICACHE_RAM_ATTR
+#endif 
+
 #include "utility/direct_pin_read.h"
 
 #if defined(ENCODER_USE_INTERRUPTS) || !defined(ENCODER_DO_NOT_USE_INTERRUPTS)
@@ -185,7 +189,7 @@ public:
 	// update() is not meant to be called from outside Encoder,
 	// but it is public to allow static interrupt routines.
 	// DO NOT call update() directly from sketches.
-	static void update(Encoder_internal_state_t *arg) {
+static void ICACHE_RAM_ATTR update(Encoder_internal_state_t *arg) {
 #if defined(__AVR__)
 		// The compiler believes this is just 1 line of code, so
 		// it will inline this function into each interrupt


### PR DESCRIPTION
You have to prefix interrupt routines on ESP8266 with ICACHE_RAM_ATTR to avoid crashes.