### PR TITLE
Add support for Arduino SAMD21 pin mapping

### DIFF
--- a/utility/interrupt_pins.h
+++ b/utility/interrupt_pins.h
@@ -206,15 +206,16 @@
   #define CORE_INT36_PIN        36
   #define CORE_INT39_PIN        39
 
-
-// Arduino Zero - TODO: interrupts do not seem to work
-//                      please help, contribute a fix!
+// SAMD21 Arduino Zero/M0 and clones - variants change pin mapping
+// but with no defines separating them so define all and ensure user
+// reads datasheet! Most of the pins on a SAMD21G18A can be used as EXTINT
 #elif defined(__SAMD21G18A__)
-  #define CORE_NUM_INTERRUPT	20
+  #define CORE_NUM_INTERRUPT	37
   #define CORE_INT0_PIN		0
   #define CORE_INT1_PIN		1
-  #define CORE_INT2_PIN		2
+  #define CORE_INT2_PIN		2 // Zero only
   #define CORE_INT3_PIN		3
+  #define CORE_INT4_PIN		4 // M0 only
   #define CORE_INT5_PIN		5
   #define CORE_INT6_PIN		6
   #define CORE_INT7_PIN		7
@@ -224,12 +225,29 @@
   #define CORE_INT11_PIN	11
   #define CORE_INT12_PIN	12
   #define CORE_INT13_PIN	13
-  #define CORE_INT14_PIN	14
-  #define CORE_INT15_PIN	15
-  #define CORE_INT16_PIN	16
+  #define CORE_INT14_PIN	14 // Zero only
+  #define CORE_INT15_PIN	15 // Zero only
+  #define CORE_INT16_PIN	16 
   #define CORE_INT17_PIN	17
   #define CORE_INT18_PIN	18
   #define CORE_INT19_PIN	19
+  #define CORE_INT20_PIN	20
+  #define CORE_INT21_PIN	21
+  #define CORE_INT22_PIN	22
+  #define CORE_INT23_PIN	23
+  #define CORE_INT24_PIN	24
+  #define CORE_INT25_PIN	25 // M0 only
+  #define CORE_INT26_PIN	26 // M0 only
+  #define CORE_INT27_PIN	27
+  #define CORE_INT28_PIN	28 // M0 only
+  #define CORE_INT29_PIN	29 // M0 only
+  #define CORE_INT34_PIN	34 // Zero only
+  #define CORE_INT35_PIN	35 // Zero only
+  #define CORE_INT36_PIN	36 // Zero only
+  #define CORE_INT37_PIN	37 // Zero only
+  #define CORE_INT38_PIN	38 // Zero only
+  #define CORE_INT42_PIN	42 // Zero only
+  #define CORE_INT43_PIN	43 // M0 only
 
 // Arduino 101
 #elif defined(__arc__)


### PR DESCRIPTION
The comment about interrupts not working on the Arduino Zero seems out of date, not enough pins are defined however - this was what prevented it working for me. I first used #13 but found that the code changes are not required to get it working - perhaps the core has changed since or @hanyazou was re configuring the pin accidentally in `setup()`?

Unfortunately SAMD variants of Arduinos have different mapping and expose different interrupt pins so not all SAMD21G18A are equal. There was no define that I could find separating them but the variant.cpp manages the hardware pin mapping so there is no issue with a user specifying a pin that does not map to an interrupt other than it not working. I've commented exclusive pins.