### PR TITLE
Add support for ATmega32u2 and ATmega16u2

### DIFF
--- a/utility/interrupt_pins.h
+++ b/utility/interrupt_pins.h
@@ -66,12 +66,12 @@
 // ATmega32u2 and ATmega32u16 based boards with HoodLoader2
 #elif defined(__AVR_ATmega32U2__) || defined(__AVR_ATmega16U2__)
   #define CORE_NUM_INTERRUPT 8
-  #define CORE_INT0_PIN 13
-  #define CORE_INT1_PIN 14
-  #define CORE_INT2_PIN 15
-  #define CORE_INT3_PIN 16
-  #define CORE_INT4_PIN 8
-  #define CORE_INT5_PIN 17
+  #define CORE_INT0_PIN 8
+  #define CORE_INT1_PIN 17
+  #define CORE_INT2_PIN 13
+  #define CORE_INT3_PIN 14
+  #define CORE_INT4_PIN 15
+  #define CORE_INT5_PIN 16
   #define CORE_INT6_PIN 19
   #define CORE_INT7_PIN 20
 

--- a/utility/interrupt_pins.h
+++ b/utility/interrupt_pins.h
@@ -63,6 +63,18 @@
   #define CORE_INT1_PIN		11
   #define CORE_INT2_PIN		2
 
+// ATmega32u2 and ATmega32u16 based boards with HoodLoader2
+#elif defined(__AVR_ATmega32U2__) || defined(__AVR_ATmega16U2__)
+  #define CORE_NUM_INTERRUPT 8
+  #define CORE_INT0_PIN 13
+  #define CORE_INT1_PIN 14
+  #define CORE_INT2_PIN 15
+  #define CORE_INT3_PIN 16
+  #define CORE_INT4_PIN 8
+  #define CORE_INT5_PIN 17
+  #define CORE_INT6_PIN 19
+  #define CORE_INT7_PIN 20
+
 // Chipkit Uno32 - attachInterrupt may not support CHANGE option
 #elif defined(__PIC32MX__) && defined(_BOARD_UNO_)
   #define CORE_NUM_INTERRUPT	5


### PR DESCRIPTION
This pull request adds support for all boards (including official ones like UNO, MEGA, ...) that have the "additional USB side" Atmel Microcontroller.

If you flash "HoodLoader2" into this chip, then it can be programmed with own sketches.

Would be great if you could accept this pull request as it is not possible to define the variables in my sketch. In Encoder.cpp you write:

// Yes, all the code is in the header file, to provide the user
// configure options with #define (before they include it), and
// to facilitate some crafty optimizations!

This doesn't work for the interrupt defines as you have "#include "Encoder.h"" in this cpp file and Arduino will compile libraries first --> Errors out immediately.

Link to HoodLoader2: https://github.com/NicoHood/HoodLoader2