### PR TITLE
Improving compatibility with SAMD51

### DIFF
--- a/utility/direct_pin_read.h
+++ b/utility/direct_pin_read.h
@@ -52,12 +52,19 @@
 #define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
 #define DIRECT_PIN_READ(base, mask)     (((*(base)) & (mask)) ? 1 : 0)
 
-#elif defined(__SAMD21G18A__) || defined(__SAMD51__)
+#elif defined(__SAMD21G18A__)
 
 #define IO_REG_TYPE                     uint32_t
 #define PIN_TO_BASEREG(pin)             portModeRegister(digitalPinToPort(pin))
 #define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
 #define DIRECT_PIN_READ(base, mask)     (((*((base)+8)) & (mask)) ? 1 : 0)
+
+#elif defined(__SAMD51__)
+
+#define IO_REG_TYPE                     uint32_t
+#define PIN_TO_BASEREG(pin)             portInputRegister(digitalPinToPort(pin))
+#define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
+#define DIRECT_PIN_READ(base, mask)     (((*(base)) & (mask)) ? 1 : 0)
 
 #elif defined(RBL_NRF51822)
 

--- a/utility/interrupt_pins.h
+++ b/utility/interrupt_pins.h
@@ -256,7 +256,7 @@
   #define CORE_INT30_PIN	30
 
 #elif defined(__SAMD51__)
-  #define CORE_NUM_INTERRUPT	30
+  #define CORE_NUM_INTERRUPT	26
   #define CORE_INT0_PIN		0
   #define CORE_INT1_PIN		1
   #define CORE_INT2_PIN		2
@@ -283,10 +283,6 @@
   #define CORE_INT23_PIN	23
   #define CORE_INT24_PIN	24
   #define CORE_INT25_PIN	25
-  #define CORE_INT26_PIN	26
-  #define CORE_INT27_PIN	27
-  #define CORE_INT28_PIN	28
-  #define CORE_INT29_PIN	29
 
 // Arduino 101
 #elif defined(__arc__)

--- a/utility/interrupt_pins.h
+++ b/utility/interrupt_pins.h
@@ -221,12 +221,13 @@
 
 // Arduino Zero - TODO: interrupts do not seem to work
 //                      please help, contribute a fix!
-#elif defined(__SAMD21G18A__) || defined(__SAMD51__)
-  #define CORE_NUM_INTERRUPT	20
+#elif defined(__SAMD21G18A__)
+  #define CORE_NUM_INTERRUPT	31
   #define CORE_INT0_PIN		0
   #define CORE_INT1_PIN		1
   #define CORE_INT2_PIN		2
   #define CORE_INT3_PIN		3
+  #define CORE_INT4_PIN		4
   #define CORE_INT5_PIN		5
   #define CORE_INT6_PIN		6
   #define CORE_INT7_PIN		7
@@ -242,6 +243,50 @@
   #define CORE_INT17_PIN	17
   #define CORE_INT18_PIN	18
   #define CORE_INT19_PIN	19
+  #define CORE_INT20_PIN	20
+  #define CORE_INT21_PIN	21
+  #define CORE_INT22_PIN	22
+  #define CORE_INT23_PIN	23
+  #define CORE_INT24_PIN	24
+  #define CORE_INT25_PIN	25
+  #define CORE_INT26_PIN	26
+  #define CORE_INT27_PIN	27
+  #define CORE_INT28_PIN	28
+  #define CORE_INT29_PIN	29
+  #define CORE_INT30_PIN	30
+
+#elif defined(__SAMD51__)
+  #define CORE_NUM_INTERRUPT	30
+  #define CORE_INT0_PIN		0
+  #define CORE_INT1_PIN		1
+  #define CORE_INT2_PIN		2
+  #define CORE_INT3_PIN		3
+  #define CORE_INT4_PIN		4
+  #define CORE_INT5_PIN		5
+  #define CORE_INT6_PIN		6
+  #define CORE_INT7_PIN		7
+  #define CORE_INT8_PIN		8
+  #define CORE_INT9_PIN		9
+  #define CORE_INT10_PIN	10
+  #define CORE_INT11_PIN	11
+  #define CORE_INT12_PIN	12
+  #define CORE_INT13_PIN	13
+  #define CORE_INT14_PIN	14
+  #define CORE_INT15_PIN	15
+  #define CORE_INT16_PIN	16
+  #define CORE_INT17_PIN	17
+  #define CORE_INT18_PIN	18
+  #define CORE_INT19_PIN	19
+  #define CORE_INT20_PIN	20
+  #define CORE_INT21_PIN	21
+  #define CORE_INT22_PIN	22
+  #define CORE_INT23_PIN	23
+  #define CORE_INT24_PIN	24
+  #define CORE_INT25_PIN	25
+  #define CORE_INT26_PIN	26
+  #define CORE_INT27_PIN	27
+  #define CORE_INT28_PIN	28
+  #define CORE_INT29_PIN	29
 
 // Arduino 101
 #elif defined(__arc__)


### PR DESCRIPTION
I was using an Adafruit ItsyBitsy M4 (SAMD51 processor) and tried using this library with the SPI pins as encoder inputs, but found that they didn't work with the library, even though the pins do support interrupts. It turns out the SPI pins were pin numbers 23, 24, and 25, which was outside the pin set allowed for the SAMD51 in direct_pin_read header file.

I checked the variant.cpp file for the ItsyBitsy M4 (downloaded from https://adafruit.github.io/arduino-board-index/boards/adafruit-samd-1.2.9.tar.bz2) and found that we should support up to pin 25 to allow use of I2C and SPI pins as GPIO w/interrupts. Perhaps even more pins should be supported for larger pin-count variants of the SAMD51, but this should be sufficient for most people.

A similar check for the ItsyBitsy M0 (SAMD21-based) indicated that pins up to pin 30 should be supported for the same purpose, so I went ahead and added that change as well.