### PR TITLE
Functional interrupt

### DIFF
--- a/Encoder.cpp
+++ b/Encoder.cpp
@@ -5,6 +5,8 @@
 // configure options with #define (before they include it), and
 // to facilitate some crafty optimizations!
 
+#ifndef ENCODER_USE_FUNCTIONAL_INTERRUPTS
 Encoder_internal_state_t * Encoder::interruptArgs[];
+#endif
 
 

--- a/Encoder.h
+++ b/Encoder.h
@@ -166,7 +166,9 @@ private:
 	uint8_t interrupts_in_use;
 #endif
 public:
+#ifndef ENCODER_USE_FUNCTIONAL_INTERRUPTS
 	static Encoder_internal_state_t * interruptArgs[ENCODER_ARGLIST_SIZE];
+#endif
 
 //                           _______         _______       
 //               Pin1 ______|       |_______|       |______ Pin1


### PR DESCRIPTION
supercede #15 
take 2 on #38

Smaller Encoder::attach_interrupt, encoder state arg is stored by the Core instead of us
Redefine IRAM_ATTR  to ICACHE_RAM_ATTR to support building with ESP8266

Note, that only ESP8266 Core >= 2.5.1 places functional interrupt handler in IRAM

Some questions:
Should esp platform check go into a separate header? like interrupt_config.h
Is there a reason we must have .cpp file to build this code as stub library? looking at ifndef check around interruptArgs declaration (since we don't need it with functional interrupt code at all)