### PR TITLE
Bump version number

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Encoder
-version=1.4.1
+version=1.4.2
 author=Paul Stoffregen
 maintainer=Paul Stoffregen
 sentence=Counts quadrature pulses from rotary & linear position encoders.


### PR DESCRIPTION
Version number increment so PlatformIO takes the latest commit. Currently PlatformIO uses an old commit that doesn't have the latest changes.