### PR TITLE
Added support for ATtiny84 and 44

### DIFF
--- a/utility/interrupt_pins.h
+++ b/utility/interrupt_pins.h
@@ -32,7 +32,7 @@
   #endif
 
 // Arduino Uno, Duemilanove, Diecimila, LilyPad, Mini, Fio, etc...
-#elif defined(__AVR_ATmega328P__) || defined(__AVR_ATmega328PB__) ||defined(__AVR_ATmega168__) || defined(__AVR_ATmega8__)
+#elif defined(__AVR_ATmega328P__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega8__)
   #define CORE_NUM_INTERRUPT	2
   #define CORE_INT0_PIN		2
   #define CORE_INT1_PIN		3
@@ -47,51 +47,20 @@
   #define CORE_INT4_PIN		19
   #define CORE_INT5_PIN		18
 
-// Arduino Nano Every, Uno R2 Wifi
-#elif defined(__AVR_ATmega4809__)
-  #define CORE_NUM_INTERRUPT	13
-  #define CORE_INT0_PIN		0
-  #define CORE_INT1_PIN		1
-  #define CORE_INT2_PIN		2
-  #define CORE_INT3_PIN		3
-  #define CORE_INT4_PIN		4
-  #define CORE_INT5_PIN		5
-  #define CORE_INT6_PIN		6
-  #define CORE_INT7_PIN		7
-  #define CORE_INT8_PIN		8
-  #define CORE_INT9_PIN		9
-  #define CORE_INT10_PIN	10
-  #define CORE_INT11_PIN	11
-  #define CORE_INT12_PIN	12
-  #define CORE_INT13_PIN	13
-
 // Arduino Leonardo (untested)
 #elif defined(__AVR_ATmega32U4__) && !defined(CORE_TEENSY)
-  #define CORE_NUM_INTERRUPT	5
+  #define CORE_NUM_INTERRUPT	4
   #define CORE_INT0_PIN		3
   #define CORE_INT1_PIN		2
   #define CORE_INT2_PIN		0
   #define CORE_INT3_PIN		1
-  #define CORE_INT4_PIN		7
 
-// Sanguino (untested) and ATmega1284P
-#elif defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644__) || defined(__AVR_ATmega1284P__)
+// Sanguino (untested)
+#elif defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644__)
   #define CORE_NUM_INTERRUPT	3
   #define CORE_INT0_PIN		10
   #define CORE_INT1_PIN		11
   #define CORE_INT2_PIN		2
-
-// ATmega32u2 and ATmega32u16 based boards with HoodLoader2
-#elif defined(__AVR_ATmega32U2__) || defined(__AVR_ATmega16U2__)
-  #define CORE_NUM_INTERRUPT 8
-  #define CORE_INT0_PIN 8
-  #define CORE_INT1_PIN 17
-  #define CORE_INT2_PIN 13
-  #define CORE_INT3_PIN 14
-  #define CORE_INT4_PIN 15
-  #define CORE_INT5_PIN 16
-  #define CORE_INT6_PIN 19
-  #define CORE_INT7_PIN 20
 
 // Chipkit Uno32 - attachInterrupt may not support CHANGE option
 #elif defined(__PIC32MX__) && defined(_BOARD_UNO_)
@@ -116,24 +85,11 @@
   #define CORE_NUM_INTERRUPT    1
   #define CORE_INT0_PIN		2
 
-// ATtiny441 ATtiny841
-#elif defined(__AVR_ATtiny441__) || defined(__AVR_ATtiny841__)
+// ATtiny84 - ATtiny44
+#elif defined(__AVR_ATtiny84__) || defined(__AVR_ATtiny44__) 
   #define CORE_NUM_INTERRUPT	1
-  #define CORE_INT0_PIN		9
+  #define CORE_INT0_PIN		8
 
-//https://github.com/SpenceKonde/ATTinyCore/blob/master/avr/extras/ATtiny_x313.md
-#elif defined(__AVR_ATtinyX313__)
-  #define CORE_NUM_INTERRUPT    2
-  #define CORE_INT0_PIN		4
-  #define CORE_INT1_PIN		5
- 
-// Attiny167 same core as abobe
-#elif defined(__AVR_ATtiny167__)
-  #define CORE_NUM_INTERRUPT	2
-  #define CORE_INT0_PIN		14
-  #define CORE_INT1_PIN		3
-
-  
 // Arduino Due
 #elif defined(__SAM3X8E__) 
   #define CORE_NUM_INTERRUPT	54
@@ -208,43 +164,9 @@
   #define CORE_INT14_PIN	14
   #define CORE_INT15_PIN	15
 
-// ESP32 (https://github.com/espressif/arduino-esp32)
-#elif defined(ESP32)
-
-  #define CORE_NUM_INTERRUPT  40 
-  #define CORE_INT0_PIN		0
-  #define CORE_INT1_PIN		1
-  #define CORE_INT2_PIN		2
-  #define CORE_INT3_PIN		3
-  #define CORE_INT4_PIN		4
-  #define CORE_INT5_PIN		5
-  // GPIO6-GPIO11 are typically used to interface with the flash memory IC on 
-  // esp32, so we should avoid adding interrupts to these pins.
-  #define CORE_INT12_PIN	12
-  #define CORE_INT13_PIN	13
-  #define CORE_INT14_PIN	14
-  #define CORE_INT15_PIN	15
-  #define CORE_INT16_PIN        16
-  #define CORE_INT17_PIN        17
-  #define CORE_INT18_PIN        18
-  #define CORE_INT19_PIN        19
-  #define CORE_INT21_PIN        21
-  #define CORE_INT22_PIN        22
-  #define CORE_INT23_PIN        23
-  #define CORE_INT25_PIN        25
-  #define CORE_INT26_PIN        26
-  #define CORE_INT27_PIN        27
-  #define CORE_INT32_PIN        32
-  #define CORE_INT33_PIN        33
-  #define CORE_INT34_PIN        34
-  #define CORE_INT35_PIN        35
-  #define CORE_INT36_PIN        36
-  #define CORE_INT39_PIN        39
-
-
 // Arduino Zero - TODO: interrupts do not seem to work
 //                      please help, contribute a fix!
-#elif defined(__SAMD21G18A__) || defined(__SAMD51__)
+#elif defined(__SAMD21G18A__)
   #define CORE_NUM_INTERRUPT	20
   #define CORE_INT0_PIN		0
   #define CORE_INT1_PIN		1


### PR DESCRIPTION
Hi,
I needed to use an encoder on an ATtiny84 but the pin definitions were missing. I added them and tested it and it seems to work fine.

I would suggest to tag to version 1.4.2

Thanks and have a nice day,
Luca