### PR TITLE
Added ATtiny84 interrupt pin

### DIFF
--- a/utility/interrupt_pins.h
+++ b/utility/interrupt_pins.h
@@ -116,6 +116,11 @@
   #define CORE_NUM_INTERRUPT    1
   #define CORE_INT0_PIN		2
 
+  // ATtiny44 ATtiny84
+#elif defined(__AVR_ATtiny44__) || defined(__AVR_ATtiny84__)
+  #define CORE_NUM_INTERRUPT	1
+  #define CORE_INT0_PIN		8
+  
 // ATtiny441 ATtiny841
 #elif defined(__AVR_ATtiny441__) || defined(__AVR_ATtiny841__)
   #define CORE_NUM_INTERRUPT	1


### PR DESCRIPTION
This is PR substitutes #51 , that can be deleted

Added definition of interrupt pin for ATtiny84, which is 8 by the current Clockwise PinMapping used by the [SpenceKonde core repo](https://github.com/SpenceKonde/ATTinyCore). 

See the pinout schemes in the README of the core repo for reference