### PR TITLE
Add support for Arduino Nano 33 BLE (NRF52840)

### DIFF
--- a/utility/direct_pin_read.h
+++ b/utility/direct_pin_read.h
@@ -73,6 +73,12 @@
 #define PIN_TO_BITMASK(pin)             (pin)
 #define DIRECT_PIN_READ(base, pin)      nrf_gpio_pin_read(pin)
 
+#elif defined(ARDUINO_ARCH_NRF52840)
+#define IO_REG_TYPE                     uint32_t
+#define PIN_TO_BASEREG(pin)             (0)
+#define PIN_TO_BITMASK(pin)             digitalPinToPinName(pin)
+#define DIRECT_PIN_READ(base, pin)      nrf_gpio_pin_read(pin)
+
 #elif defined(__arc__) /* Arduino101/Genuino101 specifics */
 
 #include "scss_registers.h"

--- a/utility/interrupt_pins.h
+++ b/utility/interrupt_pins.h
@@ -327,6 +327,31 @@
   #define CORE_INT12_PIN	12
   #define CORE_INT13_PIN	13
 
+// Arduino Nano 33 BLE
+#elif defined(ARDUINO_ARCH_NRF52840)
+  #define CORE_NUM_INTERRUPT	22
+  #define CORE_INT0_PIN		0
+  #define CORE_INT1_PIN		1
+  #define CORE_INT2_PIN		2
+  #define CORE_INT3_PIN		3
+  #define CORE_INT4_PIN		4
+  #define CORE_INT5_PIN		5
+  #define CORE_INT6_PIN		6
+  #define CORE_INT7_PIN		7
+  #define CORE_INT8_PIN		8
+  #define CORE_INT9_PIN		9
+  #define CORE_INT10_PIN	10
+  #define CORE_INT11_PIN	11
+  #define CORE_INT12_PIN	12
+  #define CORE_INT13_PIN	13
+  #define CORE_INT14_PIN	A0
+  #define CORE_INT15_PIN	A1
+  #define CORE_INT16_PIN	A2
+  #define CORE_INT17_PIN	A3
+  #define CORE_INT18_PIN	A4
+  #define CORE_INT19_PIN	A5
+  #define CORE_INT20_PIN	A6
+  #define CORE_INT21_PIN	A7
 #endif
 #endif
 


### PR DESCRIPTION
Fixes #50 for the case of interrupts enabled. I did not test with interrupts disabled.

Interested in any comments, I am particularly unsure if I used the appropriate flag for detecting the NRF52840 platform.