### PR TITLE
Arduino r4 support - added

### DIFF
--- a/Encoder.h
+++ b/Encoder.h
@@ -93,10 +93,13 @@ public:
 		// through the pullup resistors, before reading
 		// the initial state
 				  pinMode(0, OUTPUT);
-  pinMode(1, OUTPUT); pinMode(5, OUTPUT);
+  pinMode(1, OUTPUT); pinMode(5, OUTPUT); pinMode(8, OUTPUT);
+  pinMode(7, OUTPUT);
 			digitalWrite(0, LOW);
 			digitalWrite(1, LOW);
 			digitalWrite(5, LOW);
+			digitalWrite(8, LOW);
+			digitalWrite(7, LOW);
 		delayMicroseconds(2000);
 		uint8_t s = 0;
 		if (DIRECT_PIN_READ(encoder.pin1_register, encoder.pin1_bitmask)) s |= 1;
@@ -105,8 +108,7 @@ public:
 #ifdef ENCODER_USE_INTERRUPTS
 		interrupts_in_use = attach_interrupt(pin1, &encoder);
 		interrupts_in_use += attach_interrupt(pin2, &encoder);
-		digitalWrite(1, LOW);
-		
+	
 #endif
 		//update_finishup();  // to force linker to include the code (does not work)
 	}
@@ -114,10 +116,7 @@ public:
 
 #ifdef ENCODER_USE_INTERRUPTS
 	inline int32_t read() {
-		digitalWrite(0, LOW);
-
 		if (interrupts_in_use < 2) {
-			digitalWrite(1, HIGH);
 			noInterrupts();
 			update(&encoder);
 		} else {
@@ -222,7 +221,7 @@ public:
 	static IRAM_ATTR void update(Encoder_internal_state_t *arg) {
 #else
 	static void update(Encoder_internal_state_t *arg) {
-		 digitalWrite(0,HIGH);
+		digitalWrite(7, HIGH);
 #endif
 #if defined(__AVR__)
 		// The compiler believes this is just 1 line of code, so
@@ -309,7 +308,6 @@ public:
 		"L%=end:"				"\n"
 		: : "x" (arg) : "r22", "r23", "r24", "r25", "r30", "r31");
 #else
-	 digitalWrite(1,HIGH);
 		uint8_t p1val = DIRECT_PIN_READ(arg->pin1_register, arg->pin1_bitmask);
 		uint8_t p2val = DIRECT_PIN_READ(arg->pin2_register, arg->pin2_bitmask);
 		uint8_t state = arg->state & 3;
@@ -417,22 +415,21 @@ private:
 		#endif
 		#ifdef CORE_INT2_PIN
 			case CORE_INT2_PIN:
+				digitalWrite(5, HIGH);
 				interruptArgs[2] = state;
-				digitalWrite(0, HIGH);
 				attachInterrupt(2, isr2, CHANGE);
 				break;
 		#endif
 		#ifdef CORE_INT3_PIN
 			case CORE_INT3_PIN:
+				digitalWrite(8, HIGH);
 				interruptArgs[3] = state;
-				digitalWrite(1, HIGH);
 				attachInterrupt(3, isr3, CHANGE);
 				break;
 		#endif
 		#ifdef CORE_INT4_PIN
 			case CORE_INT4_PIN:
 				interruptArgs[4] = state;
-\
 				attachInterrupt(4, isr4, CHANGE);
 				break;
 		#endif
@@ -783,10 +780,10 @@ private:
 	static ENCODER_ISR_ATTR void isr1(void) { update(interruptArgs[1]); }
 	#endif
 	#ifdef CORE_INT2_PIN
-	static ENCODER_ISR_ATTR void isr2(void) {digitalWrite(5,HIGH); update(interruptArgs[2]); }
+	static ENCODER_ISR_ATTR void isr2(void) {digitalWrite(0,HIGH); update(interruptArgs[2]); }
 	#endif
 	#ifdef CORE_INT3_PIN
-	static ENCODER_ISR_ATTR void isr3(void) {digitalWrite(5,HIGH); update(interruptArgs[3]);}
+	static ENCODER_ISR_ATTR void isr3(void) {digitalWrite(1,HIGH); update(interruptArgs[3]);}
 	#endif
 	#ifdef CORE_INT4_PIN
 	static ENCODER_ISR_ATTR void isr4(void) { update(interruptArgs[4]); }

--- a/Encoder.h
+++ b/Encoder.h
@@ -74,7 +74,12 @@ typedef struct {
 class Encoder
 {
 public:
-	Encoder(uint8_t pin1, uint8_t pin2) {
+	// one step setup like before
+	Encoder(uint8_t pin1, uint8_t pin2) { begin(pin1, pin2);}
+
+	// two step setup for platforms that have issues with constructor ordering
+	Encoder() { }
+	void begin(uint8_t pin1, uint8_t pin2) {
 		#ifdef INPUT_PULLUP
 		pinMode(pin1, INPUT_PULLUP);
 		pinMode(pin2, INPUT_PULLUP);
@@ -92,14 +97,6 @@ public:
 		// allow time for a passive R-C filter to charge
 		// through the pullup resistors, before reading
 		// the initial state
-				  pinMode(0, OUTPUT);
-  pinMode(1, OUTPUT); pinMode(5, OUTPUT); pinMode(8, OUTPUT);
-  pinMode(7, OUTPUT);
-			digitalWrite(0, LOW);
-			digitalWrite(1, LOW);
-			digitalWrite(5, LOW);
-			digitalWrite(8, LOW);
-			digitalWrite(7, LOW);
 		delayMicroseconds(2000);
 		uint8_t s = 0;
 		if (DIRECT_PIN_READ(encoder.pin1_register, encoder.pin1_bitmask)) s |= 1;
@@ -108,7 +105,6 @@ public:
 #ifdef ENCODER_USE_INTERRUPTS
 		interrupts_in_use = attach_interrupt(pin1, &encoder);
 		interrupts_in_use += attach_interrupt(pin2, &encoder);
-	
 #endif
 		//update_finishup();  // to force linker to include the code (does not work)
 	}
@@ -221,7 +217,6 @@ public:
 	static IRAM_ATTR void update(Encoder_internal_state_t *arg) {
 #else
 	static void update(Encoder_internal_state_t *arg) {
-		digitalWrite(7, HIGH);
 #endif
 #if defined(__AVR__)
 		// The compiler believes this is just 1 line of code, so
@@ -415,14 +410,12 @@ private:
 		#endif
 		#ifdef CORE_INT2_PIN
 			case CORE_INT2_PIN:
-				digitalWrite(5, HIGH);
 				interruptArgs[2] = state;
 				attachInterrupt(2, isr2, CHANGE);
 				break;
 		#endif
 		#ifdef CORE_INT3_PIN
 			case CORE_INT3_PIN:
-				digitalWrite(8, HIGH);
 				interruptArgs[3] = state;
 				attachInterrupt(3, isr3, CHANGE);
 				break;
@@ -780,10 +773,10 @@ private:
 	static ENCODER_ISR_ATTR void isr1(void) { update(interruptArgs[1]); }
 	#endif
 	#ifdef CORE_INT2_PIN
-	static ENCODER_ISR_ATTR void isr2(void) {digitalWrite(0,HIGH); update(interruptArgs[2]); }
+	static ENCODER_ISR_ATTR void isr2(void) { update(interruptArgs[2]); }
 	#endif
 	#ifdef CORE_INT3_PIN
-	static ENCODER_ISR_ATTR void isr3(void) {digitalWrite(1,HIGH); update(interruptArgs[3]);}
+	static ENCODER_ISR_ATTR void isr3(void) { update(interruptArgs[3]);}
 	#endif
 	#ifdef CORE_INT4_PIN
 	static ENCODER_ISR_ATTR void isr4(void) { update(interruptArgs[4]); }

--- a/utility/direct_pin_read.h
+++ b/utility/direct_pin_read.h
@@ -111,6 +111,13 @@ IO_REG_TYPE directRead(volatile IO_REG_TYPE *base, IO_REG_TYPE pin)
 }
 #define DIRECT_PIN_READ(base, pin)      directRead(base, pin)
 
+#elif defined(ARDUINO_UNOR4_WIFI) || defined(ARDUINO_UNOR4_MINIMA) /*Arduino UnoR4 */
+
+#define IO_REG_TYPE			uint32_t
+#define PIN_TO_BASEREG(pin)             (volatile uint32_t*)(portInputRegister(digitalPinToPort(pin)))
+#define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
+#define DIRECT_PIN_READ(base, mask)     (((*(base)) & (mask)) ? 1 : 0)
+
 #endif
 
 #endif

--- a/utility/interrupt_config.h
+++ b/utility/interrupt_config.h
@@ -1,4 +1,4 @@
-#if defined(__AVR__)
+#if defined(__AVR__)  
 
 #include <avr/io.h>
 #include <avr/interrupt.h>

--- a/utility/interrupt_pins.h
+++ b/utility/interrupt_pins.h
@@ -385,7 +385,7 @@
   // #define CORE_INT21_PIN	A7
 
 // Arduino Uno R4
-#elif defined(ARDUINO_UNOR4_WIFI) || defined(ARDUINO_UNOR4_MINIMA)
+#elif defined(ARDUINO_UNOR4_MINIMA)
 //0, 1, 2, 3, 8, 12, 13, 15, 16, 17, 18 and 19.
   #define CORE_NUM_INTERRUPT	12
   #define CORE_INT0_PIN		0
@@ -395,6 +395,21 @@
   #define CORE_INT8_PIN		8
   #define CORE_INT12_PIN	12
   #define CORE_INT13_PIN	13
+  #define CORE_INT15_PIN	15
+  #define CORE_INT16_PIN	16
+  #define CORE_INT17_PIN	17
+  #define CORE_INT18_PIN	18
+  #define CORE_INT19_PIN	19
+#elif defined(ARDUINO_UNOR4_WIFI)
+//0, 1, 2, 3, 8, 12, 13, 15, 16, 17, 18 and 19.
+  #define CORE_NUM_INTERRUPT	12
+  #define CORE_INT0_PIN		0
+  #define CORE_INT1_PIN		1
+  #define CORE_INT2_PIN		2
+  #define CORE_INT3_PIN		3
+  #define CORE_INT8_PIN		8
+  #define CORE_INT11_PIN	11
+  #define CORE_INT12_PIN	12
   #define CORE_INT15_PIN	15
   #define CORE_INT16_PIN	16
   #define CORE_INT17_PIN	17

--- a/utility/interrupt_pins.h
+++ b/utility/interrupt_pins.h
@@ -383,6 +383,23 @@
   #define CORE_INT19_PIN	19
   // #define CORE_INT20_PIN	A6
   // #define CORE_INT21_PIN	A7
+
+// Arduino Uno R4
+#elif defined(ARDUINO_UNOR4_WIFI) || defined(ARDUINO_UNOR4_MINIMA)
+//0, 1, 2, 3, 8, 12, 13, 15, 16, 17, 18 and 19.
+  #define CORE_NUM_INTERRUPT	12
+  #define CORE_INT0_PIN		0
+  #define CORE_INT1_PIN		1
+  #define CORE_INT2_PIN		2
+  #define CORE_INT3_PIN		3
+  #define CORE_INT8_PIN		8
+  #define CORE_INT12_PIN	12
+  #define CORE_INT13_PIN	13
+  #define CORE_INT15_PIN	15
+  #define CORE_INT16_PIN	16
+  #define CORE_INT17_PIN	17
+  #define CORE_INT18_PIN	18
+  #define CORE_INT19_PIN	19
 #endif
 #endif
 

--- a/utility/interrupt_pins.h
+++ b/utility/interrupt_pins.h
@@ -387,7 +387,7 @@
 // Arduino Uno R4
 #elif defined(ARDUINO_UNOR4_MINIMA)
 //0, 1, 2, 3, 8, 12, 13, 15, 16, 17, 18 and 19.
-  #define CORE_NUM_INTERRUPT	12
+  #define CORE_NUM_INTERRUPT	20
   #define CORE_INT0_PIN		0
   #define CORE_INT1_PIN		1
   #define CORE_INT2_PIN		2
@@ -401,8 +401,8 @@
   #define CORE_INT18_PIN	18
   #define CORE_INT19_PIN	19
 #elif defined(ARDUINO_UNOR4_WIFI)
-//0, 1, 2, 3, 8, 12, 13, 15, 16, 17, 18 and 19.
-  #define CORE_NUM_INTERRUPT	12
+//0, 1, 2, 3, 8, 11, 12, 15, 16, 17, 18 and 19.
+  #define CORE_NUM_INTERRUPT	20
   #define CORE_INT0_PIN		0
   #define CORE_INT1_PIN		1
   #define CORE_INT2_PIN		2


### PR DESCRIPTION
@PaulStoffregen - @KurtE

When trying to update the library for the new R4 boards (Minima and WiFi) ran into an issue where attaching the interrupt did not work.  Thanks to @KurtE found that the issue was with doing it from the constructor which took a while to track down.  But he came up with a simple solution that maintains backward compatibility.  More can found here: https://forum.arduino.cc/t/encoder-library-attachinterrupt-not-working-from-within-library/1149007

Basically creates a begin method that can be used but when you begin:
```
Encoder myEnc ;

void setup() { myEnc.begin(2,3); }
```
This can be used for any board.  This method still works though:
```
Encoder myEnc(2, 3) ;
```
without using begin in the setup.

I did try it with a Teensy 4.1, Uno, Mega, Nano 33 IoT, and adafruits metro Express m0 board. 