### PR TITLE
Restore `IO_REG_TYPE` definition for AVR

### DIFF
--- a/utility/direct_pin_read.h
+++ b/utility/direct_pin_read.h
@@ -3,6 +3,7 @@
 
 #if defined(__AVR__)
 
+#define IO_REG_TYPE                     uint8_t
 #define PIN_TO_BASEREG(pin)             (portInputRegister(digitalPinToPort(pin)))
 #define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
 #define DIRECT_PIN_READ(base, mask)     (((*(base)) & (mask)) ? 1 : 0)


### PR DESCRIPTION
The definition of the `IO_REG_TYPE` macro when compiling for an AVR target was accidentally removed by https://github.com/PaulStoffregen/Encoder/pull/102:

https://github.com/PaulStoffregen/Encoder/commit/063b39006ee081a9a3f3c9e100a3980e2e8c2b2d#diff-334c08ee1cc76e8313e155ce41d8d06f284a691a9d492996f98c5e5731ac0f60L6

This resulted in the library failing to compile for those targets:

```text
Encoder.h:66:11: error: 'IO_REG_TYPE' does not name a type
  volatile IO_REG_TYPE * pin1_register;
           ^~~~~~~~~~~
```

The macro definition is hereby restored.