### PR TITLE
Compatibility with 24 bit flash pointers on AVR with more than 64KiB of Flash (ATMEGA1280, ATMEGA2560 etc)

### DIFF
--- a/Encoder.h
+++ b/Encoder.h
@@ -264,6 +264,7 @@ public:
 			"ld 	r31, Z"			"\n\t"	// r31 = inctable[state]
 			"clc"				"\n\t"
 			"ror	r31"			"\n\t"	// direction bit to carry
+			"breq	L%=end"		"\n\t"  	// speed up on no change
 
 			"ld	r22, X+"		"\n\t" // load position to r22:r23:r24:r25
 			"ld	r23, X+"		"\n\t"

--- a/utility/direct_pin_read.h
+++ b/utility/direct_pin_read.h
@@ -1,8 +1,28 @@
 #ifndef direct_pin_read_h_
 #define direct_pin_read_h_
 
-#if defined(__AVR__)
+#if defined(RAMPZ)
+#define RESET_RAMPZ()  do {RAMPZ = 0;} while (0)
+#else
+#define RESET_RAMPZ()  do {} while (0)
+#endif
 
+
+#if defined(__AVR__) && defined(RAMPZ)
+
+#define portInputRegister_far(P) ( (volatile uint8_t *)( pgm_read_word_far( pgm_get_far_address(port_to_input_PGM) + 2*(P))) )
+#define digitalPinToBitMask_far(P) ( pgm_read_byte_far( pgm_get_far_address(digital_pin_to_bit_mask_PGM) + (P) ) )
+#define digitalPinToPort_far(P) ( pgm_read_byte_far( pgm_get_far_address(digital_pin_to_port_PGM) + (P) ) )
+
+
+#define IO_REG_TYPE			uint8_t
+#define PIN_TO_BASEREG(pin)             (portInputRegister_far(digitalPinToPort_far(pin)))
+#define PIN_TO_BITMASK(pin)             (digitalPinToBitMask_far(pin))
+#define DIRECT_PIN_READ(base, mask)     (((*(base)) & (mask)) ? 1 : 0)
+
+#elif defined(__AVR__)
+
+#define IO_REG_TYPE			uint8_t
 #define PIN_TO_BASEREG(pin)             (portInputRegister(digitalPinToPort(pin)))
 #define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
 #define DIRECT_PIN_READ(base, mask)     (((*(base)) & (mask)) ? 1 : 0)


### PR DESCRIPTION
Hi
This patch is here to make the driver compatible with AVR MPU with more than 64KiB flash memory, i.e. ATMega2056 (Arduino Mega). The original driver is not compatible and crashes when it is placed over 64KiB boundary. Also, when the Arduino's internal table port_to_input_PGM was over the 64KiB, macros PIN_TO_BASEREG and similar does not work because of Arduino's bug - macro portInputRegister and similar does not work.

I've simplified the interrupt handler, now it uses 16 bytes ram lookup table instead of calculated jump. So now is more compact and there is not problem when the routine is placed over 64KiB boundary. The calculated jump had only 16 bit pointer to the destination.
Also I've fixed the initialize, macros PIN_TO_BASEREG and PIN_TO_BITMASK  are now compatible with lookup table over the 64KiB boundary.
The init function also resets the RAMPZ register if it exists, so future calls of pgm_read_near will point to the first page of flash. 
